### PR TITLE
Fix add command message for email

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -31,7 +31,7 @@ public class AddCommand extends Command {
             + "Example: " + COMMAND_WORD + " A0235410A "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
-            + PREFIX_EMAIL + "johnd@example.com "
+            + PREFIX_EMAIL + "johndoe@u.nus.edu "
             + PREFIX_TELEGRAM_HANDLE + "@JohnOwesMoney "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";


### PR DESCRIPTION
Fixes #117

<img width="728" height="186" alt="image" src="https://github.com/user-attachments/assets/3436fd41-4c10-46ba-88ba-3abf01ceaab9" />

The example prompt now correctly displays a valid nus email