### PR TITLE
Updates the user guide URL in CadetHQ

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2526s1-cs2103t-t11-2.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);


### PR DESCRIPTION
Fixes #123 

The help URL now correctly reflects the team's product website.

<img width="554" height="61" alt="image" src="https://github.com/user-attachments/assets/259505ed-657e-4eb9-9be6-4dad7dee3bc1" />
