### PR TITLE
Improve code coverage for SortCommand and SortCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -52,6 +52,6 @@ public class SortCommandParser implements Parser<SortCommand> {
      * @return true if prefix exists in map.
      */
     private static boolean isPrefixPresent(ArgumentMultimap argumentMultimap, Prefix prefix) {
-        return argumentMultimap.getAllValues(prefix) != null && !argumentMultimap.getAllValues(prefix).isEmpty();
+        return !argumentMultimap.getAllValues(prefix).isEmpty();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -119,7 +119,7 @@ public class SortCommandTest {
      * @author ndhhh
      */
     @Test
-    public void execute_sortByNullExam_throwsError() {
+    public void execute_sortByNullExam_throwsException() {
         // Make new Sort Command by exam, with EXAM = null
         SortCommand c = new SortCommand(PREFIX_EXAM, null);
         Exception exception = assertThrows(CommandException.class, () -> {
@@ -138,7 +138,7 @@ public class SortCommandTest {
      * @author ndhhh
      */
     @Test
-    public void execute_sortByOtherPrefix_throwsError() {
+    public void execute_sortByOtherPrefix_throwsException() {
         // Make new Sort Command by email
         SortCommand c = new SortCommand(PREFIX_EMAIL);
         Exception exception = assertThrows(CommandException.class, () -> {
@@ -150,6 +150,29 @@ public class SortCommandTest {
         String actualMessage = exception.getMessage();
 
         assertEquals(expectedMessage, actualMessage);
+    }
+
+    @Test
+    public void execute_nullPrefix_throwsException() {
+        // Make new Sort Command with null prefix
+        SortCommand c = new SortCommand(null);
+        assertThrows(NullPointerException.class, () -> {
+            c.execute(model);
+        });
+    }
+
+    /**
+     * Tests executing sort command with null model.
+     * @author ndhhh
+     */
+    @Test
+    public void execute_nullModel_throwsException() {
+        SortCommand sortByName = new SortCommand(PREFIX_NAME);
+        SortCommand sortByMidterm = new SortCommand(PREFIX_EXAM, MIDTERM);
+        SortCommand sortByFinal = new SortCommand(PREFIX_EXAM, FINAL);
+        assertThrows(NullPointerException.class, () -> sortByName.execute(null));
+        assertThrows(NullPointerException.class, () -> sortByMidterm.execute(null));
+        assertThrows(NullPointerException.class, () -> sortByFinal.execute(null));
     }
 
     /**
@@ -214,13 +237,6 @@ public class SortCommandTest {
         assertTrue(sortByName.equals(sortByName));
         assertTrue(sortByMidterm.equals(sortByMidterm));
 
-        // Same values -> returns true
-        SortCommand sortByNameDuplicate = new SortCommand(PREFIX_NAME);
-        assertTrue(sortByName.equals(sortByNameDuplicate));
-
-        SortCommand sortByMidtermDuplicate = new SortCommand(PREFIX_EXAM, MIDTERM);
-        assertTrue(sortByMidterm.equals(sortByMidtermDuplicate));
-
         // different types -> returns false
         assertFalse(sortByName.equals(1));
 
@@ -230,9 +246,32 @@ public class SortCommandTest {
         // different param -> returns false
         assertFalse(sortByName.equals(sortByFinal));
         assertFalse(sortByName.equals(sortByMidterm));
+        assertFalse(sortByMidterm.equals(sortByName));
+        assertFalse(sortByFinal.equals(sortByName));
 
         // different exam -> returns false
         assertFalse(sortByMidterm.equals(sortByFinal));
+        assertFalse(sortByFinal.equals(sortByMidterm));
+
+        // Same exam and prefix -> returns true
+        SortCommand sortByNameDuplicate = new SortCommand(PREFIX_NAME);
+        assertTrue(sortByName.equals(sortByNameDuplicate));
+
+        SortCommand sortByMidtermDuplicate = new SortCommand(PREFIX_EXAM, MIDTERM);
+        assertTrue(sortByMidterm.equals(sortByMidtermDuplicate));
+
+        SortCommand sortByFinalDuplicate = new SortCommand(PREFIX_EXAM, FINAL);
+        assertTrue(sortByFinal.equals(sortByFinalDuplicate));
+
+        // Sort by name but with exam param -> returns false
+        SortCommand sortByNameWithMidterm = new SortCommand(PREFIX_NAME, MIDTERM);
+        SortCommand sortByNameWithFinal = new SortCommand(PREFIX_NAME, FINAL);
+        assertFalse(sortByName.equals(sortByNameWithMidterm));
+        assertFalse(sortByName.equals(sortByNameWithFinal));
+        assertFalse(sortByMidterm.equals(sortByNameWithMidterm));
+        assertFalse(sortByFinal.equals(sortByNameWithFinal));
+        assertFalse(sortByMidterm.equals(sortByNameWithFinal));
+        assertFalse(sortByFinal.equals(sortByNameWithMidterm));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -59,6 +59,31 @@ public class SortCommandParserTest {
     }
 
     /**
+     * Tests parsing a sort command by name with spaces around the 'n/' prefix.
+     * @author ndhhh
+     * @throws ParseException
+     */
+    @Test
+    public void parse_nameWithSpaces_success() throws ParseException {
+        SortCommand c = parser.parse("    n/   ");
+        assertEquals(sortByNameCommand, c);
+    }
+
+    @Test
+    public void parse_nameWithExtraArgs_throwsException() {
+        // Make new SortCommand
+        Exception exception = assertThrows(ParseException.class, () -> {
+            parser.parse(" n/aeiou");
+        });
+
+        // Should have same error message
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE);
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    /**
      * Tests parsing a sort command by exam scores with no argument.
      * Test should throw an ParseException
      * @author ndhhh
@@ -144,6 +169,25 @@ public class SortCommandParserTest {
         // Make new SortCommand by email
         Exception exception = assertThrows(ParseException.class, () -> {
             parser.parse(" e/");
+        });
+
+        // Should have same error message
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE);
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    /**
+     * Tests parsing a sort command with random gibberish prefix.
+     * Test should throw a ParseException
+     * @author ndhhh
+     */
+    @Test
+    public void parse_randomPrefix_throwsException() {
+        // Make new SortCommand with random prefix
+        Exception exception = assertThrows(ParseException.class, () -> {
+            parser.parse(" aeiou/");
         });
 
         // Should have same error message


### PR DESCRIPTION
Fixes #170 

* Added more testing.
* Also removed `argumentMultimap.getAllValues(prefix) != null` check in `isPrefixPresent(ArgumentMultimap, Prefix)`.
* `getAllValues(prefix)` is guaranteed to not be null (returning an empty `ArrayList`), having it in the method prevents full branch coverage as it will never be false.
* This prevents false && true and false && false from ever occurring; only true && false and true && true will occur.
* Does not affect code execution as all test cases pass and systems testing works.